### PR TITLE
Enable mypy strict mode + add build-system requires in pyproject.toml

### DIFF
--- a/option/option_.py
+++ b/option/option_.py
@@ -31,6 +31,8 @@ This module contains the Option class.
 from typing import Callable, Generic, Mapping, Optional, Union
 
 from option.types_ import A, K, T, U, V
+from option.types_ import SupportsDunderLT, SupportsDunderGT
+from option.types_ import SupportsDunderLE, SupportsDunderGE
 
 
 class Option(Generic[T]):
@@ -100,7 +102,7 @@ class Option(Generic[T]):
         """
         return NONE if val is None else cls.Some(val)  # type: ignore
 
-    def __bool__(self):
+    def __bool__(self) -> bool:
         """
         Returns the truth value of the :py:class:`Option` based on its value.
 
@@ -141,7 +143,7 @@ class Option(Generic[T]):
         """
         return not self._is_some
 
-    def expect(self, msg) -> T:
+    def expect(self, msg: object) -> T:
         """
         Unwraps the option. Raises an exception if the value is :py:data:`NONE`.
 
@@ -361,7 +363,7 @@ class Option(Generic[T]):
     def get(
             self: 'Option[Mapping[K,V]]',
             key: K,
-            default=None
+            default: Union[V, None] = None
     ) -> 'Option[V]':
         """
         Gets a mapping value by key in the contained value or returns
@@ -391,20 +393,20 @@ class Option(Generic[T]):
             return self._type.maybe(self._val.get(key, default))  # type: ignore
         return self._type.maybe(default)  # type: ignore
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash((self.__class__, self._is_some, self._val))
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         return (isinstance(other, self._type)
                 and self._is_some == other._is_some
                 and self._val == other._val)
 
-    def __ne__(self, other):
+    def __ne__(self, other: object) -> bool:
         return (not isinstance(other, self._type)
                 or self._is_some != other._is_some
                 or self._val != other._val)
 
-    def __lt__(self, other):
+    def __lt__(self: 'Option[SupportsDunderLT]', other: object) -> bool:
         if isinstance(other, self._type):
             if self._is_some == other._is_some:
                 return self._val < other._val if self._is_some else False
@@ -412,14 +414,14 @@ class Option(Generic[T]):
                 return other._is_some
         return NotImplemented
 
-    def __le__(self, other):
+    def __le__(self: 'Option[SupportsDunderLE]', other: object) -> bool:
         if isinstance(other, self._type):
             if self._is_some == other._is_some:
                 return self._val <= other._val if self._is_some else True
             return other._is_some
         return NotImplemented
 
-    def __gt__(self, other):
+    def __gt__(self: 'Option[SupportsDunderGT]', other: object) -> bool:
         if isinstance(other, self._type):
             if self._is_some == other._is_some:
                 return self._val > other._val if self._is_some else False
@@ -427,14 +429,14 @@ class Option(Generic[T]):
                 return self._is_some
         return NotImplemented
 
-    def __ge__(self, other):
+    def __ge__(self: 'Option[SupportsDunderGE]', other: object) -> bool:
         if isinstance(other, self._type):
             if self._is_some == other._is_some:
                 return self._val >= other._val if self._is_some else True
             return self._is_some
         return NotImplemented
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return 'NONE' if self.is_none else f'Some({self._val!r})'
 
 

--- a/option/result.py
+++ b/option/result.py
@@ -25,6 +25,8 @@ from typing import Any, Callable, Generic, Union
 
 from option.option_ import NONE, Option
 from option.types_ import E, F, T, U
+from option.types_ import SupportsDunderLT, SupportsDunderGT
+from option.types_ import SupportsDunderLE, SupportsDunderGE
 
 
 class Result(Generic[T, E]):
@@ -46,7 +48,7 @@ class Result(Generic[T, E]):
     """
     __slots__ = ('_val', '_is_ok', '_type')
 
-    def __init__(self, val: Union[T, E], is_ok: bool, *, _force=False) -> None:
+    def __init__(self, val: Union[T, E], is_ok: bool, *, _force: bool = False) -> None:
         if not _force:
             raise TypeError(
                 'Cannot directly initialize, '
@@ -96,7 +98,7 @@ class Result(Generic[T, E]):
         """
         return cls(err, False, _force=True)
 
-    def __bool__(self):
+    def __bool__(self) -> bool:
         return self._is_ok
 
     @property
@@ -292,7 +294,7 @@ class Result(Generic[T, E]):
         """
         return self._val if self._is_ok else op(self._val)  # type: ignore
 
-    def expect(self, msg) -> T:
+    def expect(self, msg: object) -> T:
         """
         Returns the success value in the :class:`Result` or raises
         a ``ValueError`` with a provided message.
@@ -346,7 +348,7 @@ class Result(Generic[T, E]):
             raise ValueError(self._val)
         return self._val  # type: ignore
 
-    def expect_err(self, msg) -> E:
+    def expect_err(self, msg: object) -> E:
         """
         Returns the error value in a :class:`Result`, or raises a
         ``ValueError`` with the provided message.
@@ -375,44 +377,44 @@ class Result(Generic[T, E]):
             raise ValueError(msg)
         return self._val  # type: ignore
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f'Ok({self._val!r})' if self._is_ok else f'Err({self._val!r})'
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash((self._type, self._is_ok, self._val))
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         return (isinstance(other, self._type)
                 and self._is_ok == other._is_ok
                 and self._val == other._val)
 
-    def __ne__(self, other):
+    def __ne__(self, other: object) -> bool:
         return (not isinstance(other, self._type)
                 or self._is_ok != other._is_ok
                 or self._val != other._val)
 
-    def __lt__(self, other):
+    def __lt__(self: 'Result[SupportsDunderLT, SupportsDunderLT]', other: object) -> bool:
         if isinstance(other, self._type):
             if self._is_ok == other._is_ok:
                 return self._val < other._val
             return self._is_ok
         return NotImplemented
 
-    def __le__(self, other):
+    def __le__(self: 'Result[SupportsDunderLE, SupportsDunderLE]', other: object) -> bool:
         if isinstance(other, self._type):
             if self._is_ok == other._is_ok:
                 return self._val <= other._val
             return self._is_ok
         return NotImplemented
 
-    def __gt__(self, other):
+    def __gt__(self: 'Result[SupportsDunderGT, SupportsDunderGT]', other: object) -> bool:
         if isinstance(other, self._type):
             if self._is_ok == other._is_ok:
                 return self._val > other._val
             return other._is_ok
         return NotImplemented
 
-    def __ge__(self, other):
+    def __ge__(self: 'Result[SupportsDunderGE, SupportsDunderGE]', other: object) -> bool:
         if isinstance(other, self._type):
             if self._is_ok == other._is_ok:
                 return self._val >= other._val

--- a/option/types_.py
+++ b/option/types_.py
@@ -22,7 +22,7 @@
 
 # pylint: skip-file
 
-from typing import TypeVar
+from typing import Protocol, TypeVar
 
 T = TypeVar('T')
 U = TypeVar('U')
@@ -33,3 +33,19 @@ V = TypeVar('V')
 
 E = TypeVar('E')
 F = TypeVar('F')
+
+
+class SupportsDunderLT(Protocol):
+    def __lt__(self, __other: object) -> bool: ...
+
+
+class SupportsDunderGT(Protocol):
+    def __gt__(self, __other: object) -> bool: ...
+
+
+class SupportsDunderLE(Protocol):
+    def __le__(self, __other: object) -> bool: ...
+
+
+class SupportsDunderGE(Protocol):
+    def __ge__(self, __other: object) -> bool: ...

--- a/option/types_.py
+++ b/option/types_.py
@@ -22,7 +22,14 @@
 
 # pylint: skip-file
 
-from typing import Protocol, TypeVar
+import sys
+from typing import TypeVar
+
+if sys.version_info >= (3, 8):
+    from typing import Protocol
+else:
+    from typing_extensions import Protocol
+
 
 T = TypeVar('T')
 U = TypeVar('U')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ include = ['option/py.typed', 'option/**/*.py', 'LICENSE']
 
 [tool.poetry.dependencies]
 python = ">=3.7,<4"
+typing-extensions = { version = ">=4.0", python = "<3.8" }
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,3 +24,8 @@ mypy = "^0.942"
 Sphinx = "^4.5.0"
 pylint = "^2.13.3"
 bump2version = "^1.0.0"
+
+[tool.mypy]
+strict = true
+show_column_numbers = true
+show_error_codes = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["poetry_core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
 [tool.poetry]
 name = "option"
 version = "2.0.0"


### PR DESCRIPTION
- Added configuration for mypy strict mode in `pyproject.toml`
- Added annotations for un-annotated parameters and return types

Without strict mode, all un-annotated variables are treated as Any, which disables a lot of type safety checks,
And it becomes annoying to use this if you have enabled strict mode yourself, because of all the errors that can only be fixed by modifying the code for the library.
